### PR TITLE
Issue 156 | Resolve "every day" conflict of DOM segment with DOW segment 

### DIFF
--- a/lib/ExpressionDescriptor.cs
+++ b/lib/ExpressionDescriptor.cs
@@ -486,6 +486,13 @@ namespace CronExpressionDescriptor
               description = String.Format(GetString("CommaDaysBeforeTheLastDayOfTheMonth"), offSetDays);
               break;
             }
+            else if (expression == "*" && m_expressionParts[5] != "*")
+            {
+              // DOW is specified, but DOM is *, so do not generate DOM description.
+              // Otherwise, we could get a contradiction like "every day, on Tuesday"
+              description = string.Empty;
+              break;
+            }
             else
             {
               description = GetSegmentDescription(expression,

--- a/test/TestFormats.en.cs
+++ b/test/TestFormats.en.cs
@@ -544,9 +544,15 @@ namespace CronExpressionDescriptor.Test
     }
 
     [Fact]
-    public void EveryYear(){
-        Assert.Equal("Every 10 minutes, Monday through Friday", GetDescription("0/10 * ? * MON-FRI *"));
-        
+    public void Tuesday9()
+    {
+      Assert.Equal("At 09:00 AM, only on Tuesday", GetDescription("0 9 * * 2"));
+    }
+
+    [Fact]
+    public void EveryYear()
+    {
+      Assert.Equal("Every 10 minutes, Monday through Friday", GetDescription("0/10 * ? * MON-FRI *"));
     }
   }
 }

--- a/test/TestFormats.ro.cs
+++ b/test/TestFormats.ro.cs
@@ -46,7 +46,7 @@ namespace CronExpressionDescriptor.Test
         public void TestTimeOfDayCertainDaysOfWeek()
         {
             Harness(cron: "0 23 ? * MON-FRI", expected: "La 23:00, de luni până vineri"
-                , expectedVerbose: "La 23:00, în fiecare zi, de luni până vineri");
+                , expectedVerbose: "La 23:00, de luni până vineri");
         }
 
         [Fact]
@@ -87,7 +87,7 @@ namespace CronExpressionDescriptor.Test
         {
             Harness(cron: "30 11 * * 1-5",
                 expected: "La 11:30, de luni până vineri",
-                expectedVerbose: "La 11:30, în fiecare zi, de luni până vineri");
+                expectedVerbose: "La 11:30, de luni până vineri");
         }
 
         [Fact]
@@ -134,7 +134,7 @@ namespace CronExpressionDescriptor.Test
         [Fact]
         public void TestOnceAWeek()
         {
-            Harness(cron: "46 9 * * 1", expected: "La 09:46, doar luni", expectedVerbose: "La 09:46, în fiecare zi, doar luni");
+            Harness(cron: "46 9 * * 1", expected: "La 09:46, doar luni", expectedVerbose: "La 09:46, doar luni");
         }
 
         [Fact]
@@ -177,7 +177,7 @@ namespace CronExpressionDescriptor.Test
         [Fact]
         public void TestDayOfWeekName()
         {
-            Harness(cron: "23 12 * * SUN", expected: "La 12:23, doar duminică", expectedVerbose: "La 12:23, în fiecare zi, doar duminică");
+            Harness(cron: "23 12 * * SUN", expected: "La 12:23, doar duminică", expectedVerbose: "La 12:23, doar duminică");
         }
 
         [Fact]
@@ -185,7 +185,7 @@ namespace CronExpressionDescriptor.Test
         {
             Harness(cron: "*/5 15 * * MON-FRI", 
                 expected: "La fiecare 5 minute, între 15:00 și 15:59, de luni până vineri",
-                expectedVerbose: "La fiecare 5 minute, între 15:00 și 15:59, în fiecare zi, de luni până vineri");
+                expectedVerbose: "La fiecare 5 minute, între 15:00 și 15:59, de luni până vineri");
         }
 
         [Fact]
@@ -193,7 +193,7 @@ namespace CronExpressionDescriptor.Test
         {
             Harness(cron: "* * * * MON#3", 
                 expected: "În fiecare minut, în a treia luni a lunii", 
-                expectedVerbose: "În fiecare minut, în fiecare oră, în fiecare zi, în a treia luni a lunii");
+                expectedVerbose: "În fiecare minut, în fiecare oră, în a treia luni a lunii");
         }
 
         [Fact]
@@ -201,7 +201,7 @@ namespace CronExpressionDescriptor.Test
         {
             Harness(cron: "* * * * 4L",
                 expected: "În fiecare minut, în ultima joi a lunii",
-                expectedVerbose: "În fiecare minut, în fiecare oră, în fiecare zi, în ultima joi a lunii");
+                expectedVerbose: "În fiecare minut, în fiecare oră, în ultima joi a lunii");
         }
 
         [Fact]
@@ -303,7 +303,7 @@ namespace CronExpressionDescriptor.Test
             Harness(
               cron: "0 30 10-13 ? * WED,FRI",
               expected: "La și 30 de minute, între 10:00 și 13:59, doar miercuri și vineri",
-              expectedVerbose: "La și 30 de minute, între 10:00 și 13:59, în fiecare zi, doar miercuri și vineri");            
+              expectedVerbose: "La și 30 de minute, între 10:00 și 13:59, doar miercuri și vineri");            
         }
 
         [Fact]
@@ -392,7 +392,7 @@ namespace CronExpressionDescriptor.Test
         {
             Harness(cron: "23 12 * * SUN#2", 
                 expected: "La 12:23, în a doua duminică a lunii", 
-                expectedVerbose: "La 12:23, în fiecare zi, în a doua duminică a lunii");
+                expectedVerbose: "La 12:23, în a doua duminică a lunii");
         }
 
         [Fact]
@@ -430,7 +430,7 @@ namespace CronExpressionDescriptor.Test
         {
             Harness(cron: "0 15 10 ? * */3",
                 expected: "La 10:15, la fiecare a 3-a zi a săptămânii",
-                expectedVerbose: "La 10:15, în fiecare zi, la fiecare a 3-a zi a săptămânii");
+                expectedVerbose: "La 10:15, la fiecare a 3-a zi a săptămânii");
         }
 
         [Fact]
@@ -478,7 +478,7 @@ namespace CronExpressionDescriptor.Test
             // GitHub Issue #44: https://github.com/bradymholt/cron-expression-descriptor/issues/44
             Harness(cron: "0 00 10 ? * MON-THU,SUN *",
                 expected: "La 10:00, doar de luni până joi și duminică",
-                expectedVerbose: "La 10:00, în fiecare zi, doar de luni până joi și duminică");
+                expectedVerbose: "La 10:00, doar de luni până joi și duminică");
         }
 
         [Fact]

--- a/test/TestVerbosity.cs
+++ b/test/TestVerbosity.cs
@@ -2,20 +2,30 @@ using Xunit;
 
 namespace CronExpressionDescriptor.Test
 {
-    public class TestVerbosity
+    public class TestVerbosity : Support.BaseTestFormats
     {
+
+        protected override string GetLocale()
+        {
+            return "en-US";
+        }
+
         [Fact]
         public void TestSimpleExpression()
         {
-            ExpressionDescriptor ceh = new ExpressionDescriptor("30 4 1 * *", new Options() { Verbose = true, Locale = "en-US" });
-            Assert.Equal("At 04:30 AM, on day 1 of the month", ceh.GetDescription(DescriptionTypeEnum.FULL));
+            Assert.Equal("At 04:30 AM, on day 1 of the month", GetDescription("30 4 1 * *", true));
         }
 
         [Fact]
         public void TestEveryMinuteSimpleExpression()
         {
-            ExpressionDescriptor ceh = new ExpressionDescriptor("* * * * *", new Options() { Verbose = true, Locale = "en-US" });
-            Assert.Equal("Every minute, every hour, every day", ceh.GetDescription(DescriptionTypeEnum.FULL));
+            Assert.Equal("Every minute, every hour, every day", GetDescription("* * * * *", true));
+        }
+
+        [Fact]
+        public void TestSingleDayOfTheWeek()
+        {
+            Assert.Equal("At 09:00 AM, only on Tuesday", GetDescription("0 9 * * 2", true));
         }
     }
 }


### PR DESCRIPTION
### Issue Description
This PR is to address the [issue 156](https://github.com/bradymholt/cron-expression-descriptor/issues/156)

There is an issue where the ", every day" string is added in the DOM segment but it conflicts when the DOW segment is defined as something other than "*".

For example `0 9 * * 2` returns
`At 09:00 AM, every day, only on Tuesday`
when the following is expected
`At 09:00 AM, only on Tuesday`

### Change Description
In order to rectify this, we add an additional check to `lib/ExpressionDescriptor.cs >> ExpressionDescriptor.GetDayOfMonthDescription()` such that if `DOM == "*" && DOW != "*"` then do not add the `commaEveryDay` section.

### Unit Test changes

- Two new unit test to check this case for verbose == true and verbose == false have been added.
- `TestVerbosity` class refactored to take advantage of the `BaseTestFormats`
- Second Commit, 4465e2f, Removes the `commaEveryDay` string from impacted tests. Which was `, în fiecare zi`. I do not know Romanian, but I did check each of these cases in Google Translate and believe each of these cases has improved readability without the `commaEveryDay` string. For example:
```
"0 23 ? * MON-FRI"
// Was described as
La 23:00, în fiecare zi, de luni până vineri // At 11:00 PM, every day, Monday through Friday
// But after this change it is now Described as
La 23:00, de luni până vineri // At 11:00 PM, Monday through Friday
```
